### PR TITLE
build(docker): standalone runtime; remove www/port forcing

### DIFF
--- a/.github/workflows/railway-deploy.yml
+++ b/.github/workflows/railway-deploy.yml
@@ -1,4 +1,5 @@
 name: Deploy to Railway (Dockerfile)
+
 on:
   push:
     branches: [ master ]
@@ -9,75 +10,42 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    defaults:
-      run:
-        working-directory: .
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+      RAILWAY_SERVICE_NAME: ${{ vars.RAILWAY_SERVICE_NAME }}
+      SITE_BASE_URL: ${{ vars.SITE_BASE_URL }}
     steps:
-
-      - name: Checkout source code
-        uses: actions/checkout@v4
-
-      - name: Print GitHub context (debug)
-        run: |
-          echo "Actor:   $GITHUB_ACTOR"
-          echo "Branch:  $GITHUB_REF"
-          echo "SHA:     $GITHUB_SHA"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint (non-blocking)
-        run: npm run lint --fix || true
-
-      - name: Build project
-        run: npm run build
-
       - uses: actions/checkout@v4
-
 
       - name: Install Railway CLI
         run: curl -fsSL https://railway.app/install.sh | bash
 
-
-      - name: Verify railway.json configuration
-        run: |
-          echo "Verifying railway.json exists and has correct configuration..."
-          cat railway.json
-          echo "Railway CLI version:"
-          railway --version
-
-      - name: Deploy via Railway CLI using railway.json
-        run: railway up --service "skrblai-live" --detach --ci
-
-      - name: Smoke checks (non-fatal)
-        continue-on-error: true
-        run: |
-          BASE_URL="https://skrblai.io"
-          echo "HEAD /        ->" && curl -Isf "$BASE_URL/"        | head -n 1 || true
-          echo "HEAD /sports  ->" && curl -Isf "$BASE_URL/sports"  | head -n 1 || true
-          echo "GET  /api/health ->" && curl -s "$BASE_URL/api/health" | head -n 1 || true
-
-      - name: Preflight env (debug)
+      - name: Preflight (Docker + config present)
         run: |
           echo "Service root: $(pwd)"
-          ls -la
-          test -f Dockerfile || (echo "Dockerfile not found at working dir" && exit 1)
-          test -f railway.json || (echo "railway.json not found at working dir" && exit 1)
+          test -f Dockerfile || (echo "Missing Dockerfile" && exit 1)
+          test -f railway.json || (echo "Missing railway.json" && exit 1)
 
-      - name: Auth & Link
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      - name: Verify token is present and valid
         run: |
-          railway whoami
-          railway link --project "${{ vars.RAILWAY_PROJECT_ID }}" --environment "${{ vars.RAILWAY_ENVIRONMENT_ID }}" --service "${{ vars.RAILWAY_SERVICE_NAME }}"
+          test -n "$RAILWAY_TOKEN" || (echo "RAILWAY_TOKEN missing" && exit 1)
+          railway whoami || (echo "Invalid RAILWAY_TOKEN" && exit 1)
+
+      - name: Link project/env/service (non-interactive)
+        run: |
+          railway link --project "$RAILWAY_PROJECT_ID" \
+                       --environment "$RAILWAY_ENVIRONMENT_ID" \
+                       --service "$RAILWAY_SERVICE_NAME"
 
       - name: Deploy (Dockerfile)
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: railway up --yes --verbose
 
+      - name: Post-deploy smoke (non-blocking)
+        continue-on-error: true
+        run: |
+          BASE_URL="${SITE_BASE_URL:-https://skrblai.io}"
+          echo "Smoke on ${BASE_URL}"
+          curl -Isf "$BASE_URL/" | head -n1
+          curl -s "$BASE_URL/api/health" || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,11 @@ RUN npm run build
 FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
-# Railway provides PORT; default to 3000 for local runs
+# Railway injects PORT (e.g., 8080). Default 3000 for local.
 ENV PORT=3000
-
-# Run as non-root
 RUN addgroup -S nodejs && adduser -S nextjs -G nodejs
 
 # Copy standalone output
-# This puts server.js at /app/server.js
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/static ./.next/static
@@ -32,8 +29,7 @@ COPY --from=builder /app/.next/static ./.next/static
 USER nextjs
 EXPOSE 3000
 
-# Basic healthcheck hitting our health route
-HEALTHCHECK --interval=20s --timeout=3s --retries=5 CMD wget -qO- http://127.0.0.1:${PORT}/api/health || exit 1
+HEALTHCHECK --interval=20s --timeout=3s --retries=5 \
+  CMD wget -qO- http://127.0.0.1:${PORT}/api/health || exit 1
 
-# Next standalone respects PORT and binds 0.0.0.0
 CMD ["node","server.js"]

--- a/app/api/status.ts
+++ b/app/api/status.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getOptionalServerSupabase } from '../../lib/supabase/server';
 import { systemLog } from '../../utils/systemLog';
+import { getBaseUrl } from '../../lib/url';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -30,7 +31,7 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
     }
     // Aggregate health checks
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://localhost:${process.env.PORT || 3000}`;
+    const baseUrl = getBaseUrl() || `http://localhost:${process.env.PORT || 3000}`;
     const [n8n, agents] = await Promise.all([
       fetchInternal(`${baseUrl}/api/n8n/health`, token ?? ''),
       fetchInternal(`${baseUrl}/api/agents/featured`, token ?? ''),

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,11 +6,12 @@ import type { ReactNode } from "react";
 import { Inter } from 'next/font/google';
 import { Metadata } from 'next';
 import ClientLayout from './ClientLayout';
+import { getBaseUrl } from '../lib/url';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL || 'https://skrblai.io'),
+  metadataBase: new URL(getBaseUrl() || 'https://skrblai.io'),
   title: {
     default: 'SKRBL AI - AI-Powered Business Automation & Content Creation',
     template: '%s | SKRBL AI'

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,8 @@
 import { MetadataRoute } from 'next';
+import { getBaseUrl } from '../lib/url';
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://skrblai.io';
+  const baseUrl = getBaseUrl() || 'https://skrblai.io';
   
   return {
     rules: [

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,8 @@
 import { MetadataRoute } from 'next';
+import { getBaseUrl } from '../lib/url';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://skrblai.io';
+  const baseUrl = getBaseUrl() || 'https://skrblai.io';
   const currentDate = new Date().toISOString();
   
   // Static pages

--- a/lib/env/safe.ts
+++ b/lib/env/safe.ts
@@ -1,5 +1,7 @@
+import { getBaseUrl } from '../url';
+
 export const SAFE = {
   SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL ?? '',
   SUPABASE_ANON: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '',
-  BASE_URL: process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000'
+  BASE_URL: getBaseUrl() || 'http://localhost:3000'
 };

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -1,0 +1,9 @@
+// lib/url.ts
+export const getBaseUrl = () => {
+  const raw =
+    process.env.SITE_BASE_URL ||
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    '';
+  // strip trailing slash and any accidental :PORT
+  return raw.replace(/\/$/, '').replace(/:\d+$/, '');
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -44,13 +44,7 @@ function addSecurityHeaders(response: NextResponse) {
 export async function middleware(request: NextRequest) {
   let response = NextResponse.next();
   
-  // Handle apex → www redirect (if needed)
-  const hostname = request.headers.get('host');
-  if (hostname === 'skrblai.io') {
-    const url = request.nextUrl.clone();
-    url.hostname = 'www.skrblai.io';
-    response = NextResponse.redirect(url);
-  }
+  // Removed forced www redirect - serve apex domain directly
   
   // Add security headers to all responses
   response = addSecurityHeaders(response);

--- a/utils/stripe.ts
+++ b/utils/stripe.ts
@@ -1,5 +1,6 @@
 import { loadStripe } from '@stripe/stripe-js';
 import Stripe from 'stripe';
+import { getBaseUrl } from '../lib/url';
 
 // Client-side Stripe instance
 export const getStripePromise = () => {
@@ -24,8 +25,8 @@ export const createCheckoutSession = async (userId: string, priceId: string) => 
         },
       ],
       mode: 'subscription',
-      success_url: `${process.env.NEXT_PUBLIC_BASE_URL}/account?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${process.env.NEXT_PUBLIC_BASE_URL}/pricing`,
+      success_url: `${getBaseUrl()}/account?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${getBaseUrl()}/pricing`,
       metadata: {
         userId,
       },


### PR DESCRIPTION
- Remove forced www redirect from middleware.ts (serve apex directly)
- Add lib/url.ts with getBaseUrl() utility to normalize base URLs
- Update all URL building code to use getBaseUrl() (strips port/trailing slash)
- Update Dockerfile for proper standalone Next.js runtime with healthcheck
- Fix Railway deployment workflow with proper auth validation and smoke tests

Fixes www.skrblai.io:8080 redirect issues by serving apex domain without port