### PR TITLE
Update pricing and checkout logic

### DIFF
--- a/components/pricing/BusinessPricingGrid.tsx
+++ b/components/pricing/BusinessPricingGrid.tsx
@@ -39,6 +39,13 @@ export default function BusinessPricingGrid() {
               >
                 Contact Sales {icon}
               </Link>
+            ) : plan.tier === 'curiosity' ? (
+              <Link 
+                href="/#percy"
+                className="w-full py-3 px-4 bg-gradient-to-r from-cyan-500 to-blue-500 hover:from-cyan-400 hover:to-blue-400 text-white font-bold rounded-lg transition-all duration-200 shadow-lg hover:shadow-xl text-center block"
+              >
+                Start Free {icon}
+              </Link>
             ) : (
               <BuyButton
                 sku={plan.sku}
@@ -99,7 +106,7 @@ export default function BusinessPricingGrid() {
                   cancelPath="/pricing?canceled=1"
                   disabledText="Stripe Not Enabled"
                 >
-                  Add to Plan
+                  Buy Now
                 </BuyButton>
               );
 

--- a/components/pricing/SportsPricingGrid.tsx
+++ b/components/pricing/SportsPricingGrid.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { motion } from 'framer-motion';
-import { SPORTS_PLANS, SPORTS_ADDONS } from '../../lib/sports/pricingData';
+import { SPORTS_PLANS, SPORTS_ADDONS, getSportsDisplayConfig } from '../../lib/sports/pricingData';
 import PricingCard from './PricingCard';
 import { BuyButton } from './BuyButton';
 import Link from 'next/link';
@@ -41,6 +41,13 @@ export default function SportsPricingGrid() {
               >
                 Contact Us
               </Link>
+            ) : plan.tier === 'curiosity' ? (
+              <Link 
+                href="/#percy"
+                className="w-full py-3 px-4 bg-gradient-to-r from-cyan-500 to-blue-500 hover:from-cyan-400 hover:to-blue-400 text-white font-bold rounded-lg transition-all duration-200 shadow-lg hover:shadow-xl text-center block"
+              >
+                Start Free
+              </Link>
             ) : (
               <BuyButton
                 sku={plan.sku}
@@ -53,10 +60,12 @@ export default function SportsPricingGrid() {
               </BuyButton>
             );
 
+            const displayConfig = getSportsDisplayConfig(plan.tier || '');
+            
             return (
               <PricingCard
                 key={plan.sku}
-                title={plan.tier ? `${plan.tier.charAt(0).toUpperCase() + plan.tier.slice(1)} Plan` : 'Plan'}
+                title={displayConfig?.label || (plan.tier ? `${plan.tier.charAt(0).toUpperCase() + plan.tier.slice(1)} Plan` : 'Plan')}
                 priceText={plan.priceUsd ? `$${plan.priceUsd}/month` : 'Contact for pricing'}
                 displayPrice={plan.priceUsd ? `$${plan.priceUsd}` : 'Contact'}
                 originalPriceText={plan.promoPrice ? `$${plan.promoPrice}` : undefined}
@@ -107,10 +116,10 @@ export default function SportsPricingGrid() {
               return (
                 <PricingCard
                   key={addon.sku}
-                  title={addon.sku.replace('sports_addon_', '').replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase())}
+                  title={addon.description || addon.sku.replace('sports_addon_', '').replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase())}
                   priceText={addon.priceUsd ? `$${addon.priceUsd}` : 'Contact for pricing'}
                   originalPriceText={addon.originalPrice ? `$${addon.originalPrice}` : undefined}
-                  features={[addon.description || '']}
+                  features={addon.includes}
                   cta={cta}
                   animationDelay={index * 0.1}
                 />

--- a/components/providers/GlobalModalProvider.tsx
+++ b/components/providers/GlobalModalProvider.tsx
@@ -32,8 +32,8 @@ export default function GlobalModalProvider({ children }: GlobalModalProviderPro
     const skipPages = ['/dashboard', '/agents/', '/auth/', '/api/', '/admin'];
     if (skipPages.some(page => pathname.includes(page))) return;
 
-    let exitIntentTimer: NodeJS.Timeout;
-    let mouseLeaveTimer: NodeJS.Timeout;
+    let exitIntentTimer: ReturnType<typeof setTimeout>;
+    let mouseLeaveTimer: ReturnType<typeof setTimeout>;
 
     const handleMouseLeave = (e: MouseEvent) => {
       // Only trigger if mouse is leaving from the top of the viewport

--- a/lib/sports/pricingData.ts
+++ b/lib/sports/pricingData.ts
@@ -23,7 +23,7 @@ import {
  */
 export const SPORTS_PLANS: PricingItem[] = [
   {
-    sku: "sports_plan_curiosity",
+    sku: "sports_trial_curiosity",
     vertical: "sports",
     type: "plan",
     tier: "curiosity",
@@ -32,16 +32,14 @@ export const SPORTS_PLANS: PricingItem[] = [
     quickWinsIncluded: 3,
     scansOrUploads: 3, // "uploads" for sports
     includes: [
-      "3 Video Uploads per month",
-      "3 Quick Wins (Athletic Performance)",
-      "Basic SkillSmith AI Analysis",
-      "Community Support",
-      "Free eBook: Athletic Mindset Fundamentals"
+      "3 Uploads",
+      "3 Quick Wins",
+      "SkillSmith sample analysis"
     ],
     envPriceVar: undefined // Free tier has no Stripe price
   },
   {
-    sku: "sports_plan_starter_m",
+    sku: "sports_plan_starter",
     vertical: "sports",
     type: "plan", 
     tier: "starter",
@@ -50,7 +48,7 @@ export const SPORTS_PLANS: PricingItem[] = [
     quickWinsIncluded: 10,
     scansOrUploads: 10,
     includes: [
-      ...getTierIncludes("starter"),
+      "Everything in Curiosity +",
       "10 Video Uploads per month",
       "10 Quick Wins (Performance Optimization)",
       "SkillSmith AI Analysis (Standard)",
@@ -58,10 +56,10 @@ export const SPORTS_PLANS: PricingItem[] = [
       "Priority Email Support",
       "Nutrition Basics Guide"
     ],
-    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_SPORTS_STARTER_M"
+    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_ROOKIE"
   },
   {
-    sku: "sports_plan_pro_m",
+    sku: "sports_plan_pro",
     vertical: "sports",
     type: "plan",
     tier: "pro", 
@@ -70,7 +68,7 @@ export const SPORTS_PLANS: PricingItem[] = [
     quickWinsIncluded: 25,
     scansOrUploads: 25,
     includes: [
-      ...getTierIncludes("pro"),
+      "Everything in Starter +",
       "25 Video Uploads per month",
       "25 Quick Wins (Advanced Performance)",
       "SkillSmith AI Analysis (Pro)",
@@ -80,10 +78,10 @@ export const SPORTS_PLANS: PricingItem[] = [
       "Injury Prevention Protocols",
       "Priority Chat Support"
     ],
-    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_SPORTS_PRO_M"
+    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_PRO"
   },
   {
-    sku: "sports_plan_elite_m",
+    sku: "sports_plan_elite",
     vertical: "sports", 
     type: "plan",
     tier: "elite",
@@ -92,7 +90,7 @@ export const SPORTS_PLANS: PricingItem[] = [
     quickWinsIncluded: 50,
     scansOrUploads: 50,
     includes: [
-      ...getTierIncludes("elite"),
+      "Everything in Pro +",
       "50 Video Uploads per month",
       "50 Quick Wins (Elite Performance)",
       "SkillSmith AI Analysis (Elite)",
@@ -103,7 +101,7 @@ export const SPORTS_PLANS: PricingItem[] = [
       "Competition Preparation Plans",
       "Dedicated Success Manager"
     ],
-    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_SPORTS_ELITE_M"
+    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_ALLSTAR"
   },
   {
     sku: "sports_plan_contact",
@@ -147,8 +145,8 @@ export const SPORTS_ADDONS: AddOnItem[] = [
       "Comparison with pro athletes",
       "Detailed improvement recommendations"
     ],
-    description: "AI-powered video analysis for technical skill improvement",
-    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_SPORTS_ADDON_VIDEO",
+    description: "AI Video Analysis ($29)",
+    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_ADDON_VIDEO",
     originalPrice: 29
   },
   {
@@ -165,8 +163,8 @@ export const SPORTS_ADDONS: AddOnItem[] = [
       "Confidence building exercises",
       "Competition mindset development"
     ],
-    description: "Master your mental game with advanced emotional intelligence training",
-    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_SPORTS_ADDON_EMOTION",
+    description: "Mastery of Emotion ($39)",
+    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_ADDON_EMOTION",
     originalPrice: 39
   },
   {
@@ -183,8 +181,8 @@ export const SPORTS_ADDONS: AddOnItem[] = [
       "Supplement recommendations",
       "Performance fuel timing"
     ],
-    description: "Optimize your nutrition for peak athletic performance",
-    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_SPORTS_ADDON_NUTRITION",
+    description: "Sports Nutrition Guide ($19)",
+    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_ADDON_NUTRITION",
     originalPrice: 19
   },
   {
@@ -201,8 +199,8 @@ export const SPORTS_ADDONS: AddOnItem[] = [
       "Injury prevention exercises",
       "Athletic movement patterns"
     ],
-    description: "Build unshakeable athletic foundations with comprehensive training protocols",
-    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_SPORTS_ADDON_FOUNDATION",
+    description: "Foundation Training Pack ($49)",
+    envPriceVar: "NEXT_PUBLIC_STRIPE_PRICE_ADDON_FOUNDATION",
     originalPrice: 49
   }
 ];
@@ -212,7 +210,7 @@ export const SPORTS_ADDONS: AddOnItem[] = [
  */
 export const SPORTS_PLAN_DISPLAY: Record<string, PlanDisplayConfig> = {
   curiosity: {
-    label: "Curiosity",
+    label: "Curiosity (Free Trial)",
     icon: "🎯",
     ctaText: "Start Free",
     gradient: "from-gray-500 to-slate-600"
@@ -241,7 +239,7 @@ export const SPORTS_PLAN_DISPLAY: Record<string, PlanDisplayConfig> = {
   contact: {
     label: "Contact Us",
     icon: "🤝",
-    ctaText: "Contact Sales",
+    ctaText: "Contact Us",
     ctaKind: "contact",
     gradient: "from-green-500 to-emerald-500"
   }

--- a/scripts/smoke-checkout.ts
+++ b/scripts/smoke-checkout.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env tsx
+
+/**
+ * Smoke Test for Checkout API
+ * 
+ * Tests the /api/checkout endpoint with various SKUs to ensure
+ * proper price resolution and mode handling.
+ * 
+ * ONLY runs in development environment to avoid production calls.
+ */
+
+const DEV_SERVER_URL = process.env.DEV_SERVER_URL || 'http://localhost:3000';
+
+interface CheckoutRequest {
+  sku: string;
+  mode?: "subscription" | "payment" | "trial" | "contact";
+  vertical: "sports" | "business";
+  successPath?: string;
+  cancelPath?: string;
+}
+
+interface CheckoutResponse {
+  ok: boolean;
+  url?: string;
+  sessionId?: string;
+  mode?: string;
+  error?: string;
+}
+
+async function testCheckoutEndpoint(request: CheckoutRequest): Promise<void> {
+  try {
+    console.log(`\n🧪 Testing SKU: ${request.sku} (${request.vertical})`);
+    
+    const response = await fetch(`${DEV_SERVER_URL}/api/checkout`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request),
+    });
+
+    const data: CheckoutResponse = await response.json();
+    
+    if (response.ok && data.ok) {
+      if (data.url?.startsWith('http')) {
+        console.log(`✅ SUCCESS: Stripe checkout URL received`);
+        console.log(`   URL: ${data.url.substring(0, 50)}...`);
+      } else if (data.url?.startsWith('/') || data.url?.startsWith('#')) {
+        console.log(`✅ SUCCESS: Internal redirect to ${data.url}`);
+      } else {
+        console.log(`✅ SUCCESS: Response received`);
+        console.log(`   Data:`, data);
+      }
+    } else {
+      console.log(`❌ FAILED: ${data.error || 'Unknown error'}`);
+      if (data.error?.includes('Stripe Not Enabled') || data.error?.includes('ENV variable')) {
+        console.log(`   ℹ️  This is expected if Stripe env vars are not configured`);
+      }
+    }
+  } catch (error) {
+    console.log(`💥 ERROR: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+async function runSmokeTests(): Promise<void> {
+  // Ensure we're not in production
+  if (process.env.NODE_ENV === 'production') {
+    console.log('❌ Smoke tests are disabled in production environment');
+    process.exit(1);
+  }
+
+  console.log('🚀 Starting Checkout API Smoke Tests');
+  console.log(`📍 Target server: ${DEV_SERVER_URL}`);
+
+  const testCases: CheckoutRequest[] = [
+    // Sports plans
+    {
+      sku: "sports_trial_curiosity",
+      mode: "trial",
+      vertical: "sports",
+      successPath: "/sports?status=success",
+      cancelPath: "/sports?status=cancel"
+    },
+    {
+      sku: "sports_plan_starter",
+      mode: "subscription",
+      vertical: "sports",
+      successPath: "/sports?status=success",
+      cancelPath: "/sports?status=cancel"
+    },
+    {
+      sku: "sports_plan_pro",
+      mode: "subscription",
+      vertical: "sports",
+      successPath: "/sports?status=success",
+      cancelPath: "/sports?status=cancel"
+    },
+    {
+      sku: "sports_plan_elite",
+      mode: "subscription",
+      vertical: "sports",
+      successPath: "/sports?status=success",
+      cancelPath: "/sports?status=cancel"
+    },
+    {
+      sku: "sports_plan_contact",
+      mode: "contact",
+      vertical: "sports"
+    },
+    
+    // Sports add-ons
+    {
+      sku: "sports_addon_video",
+      mode: "payment",
+      vertical: "sports",
+      successPath: "/sports?status=success",
+      cancelPath: "/sports?status=cancel"
+    },
+    {
+      sku: "sports_addon_emotion",
+      mode: "payment",
+      vertical: "sports",
+      successPath: "/sports?status=success",
+      cancelPath: "/sports?status=cancel"
+    },
+    {
+      sku: "sports_addon_nutrition",
+      mode: "payment",
+      vertical: "sports",
+      successPath: "/sports?status=success",
+      cancelPath: "/sports?status=cancel"
+    },
+    {
+      sku: "sports_addon_foundation",
+      mode: "payment",
+      vertical: "sports",
+      successPath: "/sports?status=success",
+      cancelPath: "/sports?status=cancel"
+    },
+    
+    // Business plans
+    {
+      sku: "biz_plan_curiosity",
+      mode: "trial",
+      vertical: "business",
+      successPath: "/pricing?success=1",
+      cancelPath: "/pricing?canceled=1"
+    },
+    {
+      sku: "biz_plan_starter_m",
+      mode: "subscription",
+      vertical: "business",
+      successPath: "/pricing?success=1",
+      cancelPath: "/pricing?canceled=1"
+    },
+    {
+      sku: "biz_plan_contact",
+      mode: "contact",
+      vertical: "business"
+    },
+    
+    // Business add-ons
+    {
+      sku: "biz_addon_adv_analytics",
+      mode: "payment",
+      vertical: "business",
+      successPath: "/pricing?success=1",
+      cancelPath: "/pricing?canceled=1"
+    }
+  ];
+
+  // Run all test cases
+  for (const testCase of testCases) {
+    await testCheckoutEndpoint(testCase);
+    // Small delay between requests
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  console.log('\n🏁 Smoke tests completed');
+  console.log('\nℹ️  Next steps:');
+  console.log('   1. Check server logs for detailed checkout flow');
+  console.log('   2. Verify Stripe Dashboard for test sessions (if env vars configured)');
+  console.log('   3. Test actual checkout flows in browser');
+}
+
+// Run if called directly
+if (require.main === module) {
+  runSmokeTests().catch(console.error);
+}
+
+export { runSmokeTests, testCheckoutEndpoint };


### PR DESCRIPTION
Standardize Sports and Business pricing CTAs to use the checkout API, fix pricing labels, and improve checkout API robustness.

This PR ensures all pricing plans and add-ons across both Sports and Business verticals correctly initiate Stripe checkout or handle special modes (trial, contact) via the `/api/checkout` endpoint. It also refines user-facing labels for the "Curiosity" free trial and Sports add-ons, adds comprehensive debug logging to the checkout API, and includes a development-only smoke test script for verification.

---

**Checklist:**

- [x] Curiosity shows “Start Free”.
- [x] Each Sports plan/add-on CTA triggers /api/checkout with correct SKU/mode.
- [x] Buttons auto-disable if any required env var is missing.
- [x] No UI layout changes outside pricing components.

---
<a href="https://cursor.com/background-agent?bcId=bc-71138097-948b-41c9-9589-897384aa2785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-71138097-948b-41c9-9589-897384aa2785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

