### PR TITLE
Lazy supabase init and runtime guards

### DIFF
--- a/app/api/analytics/popups/route.ts
+++ b/app/api/analytics/popups/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { getServerSupabaseAdmin } from "@/lib/supabase/server";
 import { withLogging } from "@/lib/observability/logger";
 
 export const runtime = "nodejs";
@@ -18,7 +18,14 @@ async function handlePopupAnalytics(req: NextRequest) {
       '90d': 90
     }[range] || 7;
 
-    const supabase = createServerSupabaseClient();
+    const supabase = getServerSupabaseAdmin();
+    
+    if (!supabase) {
+      return NextResponse.json(
+        { ok: false, error: 'Service temporarily unavailable' },
+        { status: 503 }
+      );
+    }
     
     // Calculate date range
     const endDate = new Date();

--- a/app/api/leads/submit/route.ts
+++ b/app/api/leads/submit/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { getServerSupabaseAdmin } from "@/lib/supabase/server";
 import { withLogging } from "@/lib/observability/logger";
 
 export const runtime = "nodejs";
@@ -38,7 +38,14 @@ async function handleLeadSubmission(req: NextRequest) {
       );
     }
 
-    const supabase = createServerSupabaseClient();
+    const supabase = getServerSupabaseAdmin();
+    
+    if (!supabase) {
+      return NextResponse.json(
+        { ok: false, error: 'Service temporarily unavailable' },
+        { status: 503 }
+      );
+    }
     
     // Check if lead already exists
     const { data: existingLead } = await supabase

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -50,10 +50,11 @@ export function validateEnvSafe() {
 }
 
 /**
- * Validates Supabase environment variables
- * Throws on missing vars or invalid formats
+ * Validates Supabase environment variables at runtime
+ * Throws on missing vars or invalid formats - only call this inside handlers
+ * @throws {Error} When environment validation fails
  */
-export function validateSupabaseEnv(): SupabaseEnv {
+export function assertEnvAtRuntime(): SupabaseEnv {
   const errors: string[] = [];
   const env: Partial<SupabaseEnv> = {};
 
@@ -110,12 +111,19 @@ export function validateSupabaseEnv(): SupabaseEnv {
 }
 
 /**
+ * @deprecated Use assertEnvAtRuntime() instead - only call inside handlers/components, not at import time
+ */
+export function validateSupabaseEnv(): SupabaseEnv {
+  return assertEnvAtRuntime();
+}
+
+/**
  * Safely validates environment without throwing
  * Returns validation result with errors array
  */
 export function validateSupabaseEnvSafe(): ValidationResult {
   try {
-    const env = validateSupabaseEnv();
+    const env = assertEnvAtRuntime();
     return { isValid: true, errors: [], env };
   } catch (error) {
     return {
@@ -131,11 +139,12 @@ export function validateSupabaseEnvSafe(): ValidationResult {
 }
 
 /**
- * Gets validated environment variables
- * Throws if validation fails
+ * Gets validated environment variables at runtime
+ * Throws if validation fails - only call inside handlers/components
+ * @deprecated Use assertEnvAtRuntime() directly
  */
 export function getSupabaseEnv(): SupabaseEnv {
-  return validateSupabaseEnv();
+  return assertEnvAtRuntime();
 }
 
 /**

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -6,17 +6,22 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
 let supabase: SupabaseClient | null = null;
 
-/** Returns a real Supabase client when public envs are present, otherwise throws error for better debugging. */
-export function getBrowserSupabase(): SupabaseClient {
+/** Returns a real Supabase client when public envs are present, otherwise returns null. Warns in dev only. */
+export function getBrowserSupabase(): SupabaseClient | null {
   if (supabase) return supabase;
 
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
   if (!url || !anon) {
-    const error = `Supabase configuration missing: ${!url ? 'NEXT_PUBLIC_SUPABASE_URL' : ''} ${!anon ? 'NEXT_PUBLIC_SUPABASE_ANON_KEY' : ''}`.trim();
-    console.error("[supabase]", error);
-    throw new Error(`Authentication service unavailable: ${error}`);
+    // Only warn in development to avoid log spam in production builds
+    if (process.env.NODE_ENV === 'development') {
+      const missing = [];
+      if (!url) missing.push('NEXT_PUBLIC_SUPABASE_URL');
+      if (!anon) missing.push('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+      console.warn("[supabase] Missing environment variables:", missing.join(', '));
+    }
+    return null;
   }
 
   try {
@@ -30,39 +35,39 @@ export function getBrowserSupabase(): SupabaseClient {
     return supabase;
   } catch (error) {
     console.error("[supabase] Failed to create client:", error);
-    throw new Error("Authentication service initialization failed");
+    return null;
   }
 }
 
-// Legacy function for backward compatibility - now creates client safely
+// Legacy function for backward compatibility - returns client or mock
 export function createSafeSupabaseClient() {
-  try {
-    return getBrowserSupabase();
-  } catch (error) {
-    console.error('Failed to create Supabase client:', error);
-    
-    // Return a mock client that prevents build errors
-    return {
-      from: () => ({
-        select: () => ({ data: null, error: new Error('Supabase not configured') }),
-        insert: () => ({ data: null, error: new Error('Supabase not configured') }),
-        update: () => ({ data: null, error: new Error('Supabase not configured') }),
-        delete: () => ({ data: null, error: new Error('Supabase not configured') }),
-        upsert: () => ({ data: null, error: new Error('Supabase not configured') }),
-      }),
-      auth: {
-        getUser: () => Promise.resolve({ data: { user: null }, error: new Error('Supabase not configured') }),
-        signOut: () => Promise.resolve({ error: new Error('Supabase not configured') }),
-        signInWithPassword: () => Promise.resolve({ data: null, error: new Error('Supabase not configured') }),
-      },
-      storage: {
-        from: () => ({
-          upload: () => Promise.resolve({ data: null, error: new Error('Supabase not configured') }),
-          download: () => Promise.resolve({ data: null, error: new Error('Supabase not configured') }),
-        }),
-      },
-    } as any;
+  const client = getBrowserSupabase();
+  
+  if (client) {
+    return client;
   }
+  
+  // Return a mock client that prevents build errors
+  return {
+    from: () => ({
+      select: () => ({ data: null, error: new Error('Supabase not configured') }),
+      insert: () => ({ data: null, error: new Error('Supabase not configured') }),
+      update: () => ({ data: null, error: new Error('Supabase not configured') }),
+      delete: () => ({ data: null, error: new Error('Supabase not configured') }),
+      upsert: () => ({ data: null, error: new Error('Supabase not configured') }),
+    }),
+    auth: {
+      getUser: () => Promise.resolve({ data: { user: null }, error: new Error('Supabase not configured') }),
+      signOut: () => Promise.resolve({ error: new Error('Supabase not configured') }),
+      signInWithPassword: () => Promise.resolve({ data: null, error: new Error('Supabase not configured') }),
+    },
+    storage: {
+      from: () => ({
+        upload: () => Promise.resolve({ data: null, error: new Error('Supabase not configured') }),
+        download: () => Promise.resolve({ data: null, error: new Error('Supabase not configured') }),
+      }),
+    },
+  } as any;
 }
 
 // Legacy export for backward compatibility


### PR DESCRIPTION
Implement lazy Supabase client initialization and runtime guards to prevent build-time crashes.

Previously, missing Supabase environment variables at build time would cause the build to fail due to top-level throws. This change refactors client creation and environment validation to be lazy and runtime-guarded, ensuring builds succeed even if variables are temporarily empty.

---
<a href="https://cursor.com/background-agent?bcId=bc-99b9f007-32be-43a5-83b4-280aba96b6e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-99b9f007-32be-43a5-83b4-280aba96b6e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

